### PR TITLE
Remove `b4a`

### DIFF
--- a/lib/pass-through-decoder.js
+++ b/lib/pass-through-decoder.js
@@ -1,5 +1,3 @@
-const b4a = require('b4a')
-
 module.exports = class PassThroughDecoder {
   constructor (encoding) {
     this.encoding = encoding
@@ -10,7 +8,7 @@ module.exports = class PassThroughDecoder {
   }
 
   decode (tail) {
-    return b4a.toString(tail, this.encoding)
+    return tail.toString(this.encoding)
   }
 
   flush () {

--- a/lib/utf8-decoder.js
+++ b/lib/utf8-decoder.js
@@ -1,5 +1,3 @@
-const b4a = require('b4a')
-
 /**
  * https://encoding.spec.whatwg.org/#utf-8-decoder
  */
@@ -25,7 +23,7 @@ module.exports = class UTF8Decoder {
         isBoundary = data[i] <= 0x7f
       }
 
-      if (isBoundary) return b4a.toString(data, 'utf8')
+      if (isBoundary) return data.toString()
     }
 
     let result = ''

--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
     "url": "https://github.com/holepunchto/text-decoder/issues"
   },
   "homepage": "https://github.com/holepunchto/text-decoder#readme",
-  "dependencies": {
-    "b4a": "^1.6.4"
-  },
   "devDependencies": {
     "brittle": "^3.3.2",
     "standard": "^17.0.0"


### PR DESCRIPTION
With the introduction of `BrowserDecoder`, we don't actually need to wrap buffer operations anymore and can just use the corresponding methods directly.